### PR TITLE
Update common.scss

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,7 +17,7 @@
 }
 
 @if $Hide_default_button == "true" {
-  button#create-topic {
-    display: none;
+  .list-controls .container #create-topic {
+    display:none
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -18,6 +18,6 @@
 
 @if $Hide_default_button == "true" {
   .list-controls .container #create-topic {
-    display:none
+    display:none;
   }
 }


### PR DESCRIPTION
New topic component does not hide the default [+New topic] button on mobile. This change will make it hide.