### PR TITLE
FEATURE: show button and redirect to login for anon visitors

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -27,3 +27,13 @@
     display: none !important;
   }
 }
+
+.anon {
+  #new-create-topic {
+    // match default login button size
+    font-size: var(--font-down-1);
+    margin-right: 0.5em;
+    position: relative;
+    top: 0.1em; // optical alignment
+  }
+}

--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DButtonTooltip from "discourse/components/d-button-tooltip";
+import routeAction from "discourse/helpers/route-action";
 import Category from "discourse/models/category";
 import i18n from "discourse-common/helpers/i18n";
 import I18n from "discourse-i18n";
@@ -86,6 +87,12 @@ export default class CustomHeaderTopicButton extends Component {
     }
   }
 
+  get showAnon() {
+    if (settings.show_to_anon && !this.currentUser) {
+      return true;
+    }
+  }
+
   @action
   createTopic() {
     this.composer.openNewTopic({
@@ -118,6 +125,17 @@ export default class CustomHeaderTopicButton extends Component {
           {{/if}}
         </:tooltip>
       </DButtonTooltip>
+    {{/if}}
+
+    {{#if this.showAnon}}
+      <DButton
+        @action={{routeAction "showLogin"}}
+        @translatedLabel={{this.createTopicLabel}}
+        @translatedTitle={{this.createTopicTitle}}
+        @icon={{settings.new_topic_button_icon}}
+        id="new-create-topic"
+        class="btn-default header-create-topic"
+      />
     {{/if}}
   </template>
 }

--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -133,6 +133,7 @@ export default class CustomHeaderTopicButton extends Component {
         @translatedLabel={{this.createTopicLabel}}
         @translatedTitle={{this.createTopicTitle}}
         @icon={{settings.new_topic_button_icon}}
+        {{! template-lint-disable no-duplicate-id }}
         id="new-create-topic"
         class="btn-default header-create-topic"
       />

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,3 +6,4 @@ en:
       new_topic_button_text: Enter the text you want the button to use. You can also leave this empty if you want to only use an icon.
       new_topic_button_title: Enter the title you want the button to use. If this is left empy, the title will be the same as the button text
       hide_default_button: Hide the default "New topic" button in topic lists?
+      show_to_anon: Show the button to logged-out visitors, and have it redirect to login on click

--- a/settings.yml
+++ b/settings.yml
@@ -6,3 +6,5 @@ new_topic_button_title:
   default: ""
 hide_default_button:
   default: true
+show_to_anon:
+  default: false

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -58,13 +58,16 @@ RSpec.describe "New topic header button", type: :system do
   end
 
   context "anonymous visitor" do
-    it "should not display a new topic button in the header for anons by default" do
+    it "when show_to_anon is disabled, it should not display a new topic button in the header" do
+      theme.update_setting(:show_to_anon, false)
+      theme.save!
+      
       visit("/")
 
       expect(page).not_to have_css("#new-create-topic")
     end
 
-    it "when show_to_anon is enabled, it should display a new topic button in the header for anons" do
+    it "when show_to_anon is enabled, it should display a new topic button in the header" do
       theme.update_setting(:show_to_anon, true)
       theme.save!
 

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -58,10 +58,30 @@ RSpec.describe "New topic header button", type: :system do
   end
 
   context "anonymous visitor" do
-    it "should not display a new topic button in the header for anons" do
+    it "should not display a new topic button in the header for anons by default" do
       visit("/")
 
       expect(page).not_to have_css("#new-create-topic")
+    end
+
+    it "when show_to_anon is enabled, it should display a new topic button in the header for anons" do
+      theme.update_setting(:show_to_anon, true)
+      theme.save!
+
+      visit("/")
+
+      expect(page).to have_css("#new-create-topic")
+    end
+
+    it "when show_to_anon is enabled, clicking the new topic button redirects to login" do
+      theme.update_setting(:show_to_anon, true)
+      theme.save!
+
+      visit("/")
+
+      find("#new-create-topic").click
+
+      expect(page).to have_css(".login-modal")
     end
   end
 end


### PR DESCRIPTION

![image](https://github.com/discourse/discourse-new-topic-button-theme-component/assets/1681963/bcf7ae44-b36b-48fe-890c-a590db2d6a43)


This shows the button in the header for anonymous visitors when `show_to_anon` is enabled (disabled by default). Clicking the button will redirect to login. 

