### PR TITLE
FIX: don't disable based on banner condition

### DIFF
--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -67,8 +67,7 @@ export default class CustomHeaderTopicButton extends Component {
       return (
         !this.canCreateTopic ||
         !this.canCreateTopicWithCategory ||
-        !this.canCreateTopicWithTag ||
-        this.currentCategory?.read_only_banner
+        !this.canCreateTopicWithTag
       );
     }
   }
@@ -85,6 +84,10 @@ export default class CustomHeaderTopicButton extends Component {
     } else {
       return this.createTopicLabel;
     }
+  }
+
+  get showDisabledTooltip() {
+    return this.createTopicDisabled && !this.currentCategory?.read_only_banner;
   }
 
   @action
@@ -111,7 +114,7 @@ export default class CustomHeaderTopicButton extends Component {
           />
         </:button>
         <:tooltip>
-          {{#if this.createTopicDisabled}}
+          {{#if this.showDisabledTooltip}}
             <DTooltip
               @icon="info-circle"
               @content={{i18n (themePrefix "button_disabled_tooltip")}}


### PR DESCRIPTION
The read only banner may be populated even if the category is not read only, so this shouldn't be a condition for disabling the button. 

I've also updated this to match the core behavior, where the disabled tooltip will not appear if a banner is shown. 