### PR TITLE
DEV: Remove state logic from theme component so button is always active

### DIFF
--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -13,9 +13,6 @@ export default class CustomHeaderTopicButton extends Component {
   @service composer;
   @service currentUser;
   @service router;
-  @service siteSettings;
-
-  canCreateTopic = this.currentUser?.can_create_topic;
 
   topic = this.router.currentRouteName.includes("topic")
     ? getOwner(this).lookup("controller:topic")
@@ -48,29 +45,6 @@ export default class CustomHeaderTopicButton extends Component {
     );
   }
 
-  get canCreateTopicWithTag() {
-    return (
-      !this.router.currentRoute.attributes?.tag?.staff ||
-      this.currentUser?.staff
-    );
-  }
-
-  get canCreateTopicWithCategory() {
-    return !this.currentCategory || this.currentCategory?.permission;
-  }
-
-  get createTopicDisabled() {
-    if (this.userHasDraft) {
-      return false;
-    } else {
-      return (
-        !this.canCreateTopic ||
-        !this.canCreateTopicWithCategory ||
-        !this.canCreateTopicWithTag
-      );
-    }
-  }
-
   get createTopicLabel() {
     return this.userHasDraft
       ? i18n("topic.open_draft")
@@ -83,10 +57,6 @@ export default class CustomHeaderTopicButton extends Component {
     } else {
       return this.createTopicLabel;
     }
-  }
-
-  get showDisabledTooltip() {
-    return this.createTopicDisabled && !this.currentCategory?.read_only_banner;
   }
 
   @action
@@ -109,7 +79,6 @@ export default class CustomHeaderTopicButton extends Component {
             @icon={{settings.new_topic_button_icon}}
             id="new-create-topic"
             class="btn-default header-create-topic"
-            disabled={{this.createTopicDisabled}}
           />
         </:button>
         <:tooltip>

--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -70,7 +70,7 @@ export default class CustomHeaderTopicButton extends Component {
 
   <template>
     {{#if this.currentUser}}
-      <DButtonTooltip>
+      <DButton>
         <:button>
           <DButton
             @action={{this.createTopic}}
@@ -81,15 +81,7 @@ export default class CustomHeaderTopicButton extends Component {
             class="btn-default header-create-topic"
           />
         </:button>
-        <:tooltip>
-          {{#if this.showDisabledTooltip}}
-            <DTooltip
-              @icon="circle-info"
-              @content={{i18n (themePrefix "button_disabled_tooltip")}}
-            />
-          {{/if}}
-        </:tooltip>
-      </DButtonTooltip>
+      </DButton>
     {{else if settings.show_to_anon}}
       <DButton
         @action={{routeAction "showLogin"}}

--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -70,18 +70,14 @@ export default class CustomHeaderTopicButton extends Component {
 
   <template>
     {{#if this.currentUser}}
-      <DButton>
-        <:button>
-          <DButton
-            @action={{this.createTopic}}
-            @translatedLabel={{this.createTopicLabel}}
-            @translatedTitle={{this.createTopicTitle}}
-            @icon={{settings.new_topic_button_icon}}
-            id="new-create-topic"
-            class="btn-default header-create-topic"
-          />
-        </:button>
-      </DButton>
+      <DButton
+        @action={{this.createTopic}}
+        @translatedLabel={{this.createTopicLabel}}
+        @translatedTitle={{this.createTopicTitle}}
+        @icon={{settings.new_topic_button_icon}}
+        id="new-create-topic"
+        class="btn-default header-create-topic"
+      />
     {{else if settings.show_to_anon}}
       <DButton
         @action={{routeAction "showLogin"}}

--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -3,11 +3,9 @@ import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
-import DButtonTooltip from "discourse/components/d-button-tooltip";
 import routeAction from "discourse/helpers/route-action";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
-import DTooltip from "float-kit/components/d-tooltip";
 
 export default class CustomHeaderTopicButton extends Component {
   @service composer;

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "New topic header button", type: :system do
       it "can open composer" do
         visit("/c/#{category.slug}/#{category.id}")
 
-        expect(page).to have_no_css("#create-topic")
+        expect(page).to have_css("#new-create-topic:not([disabled])")
       end
     end
   end

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -68,10 +68,10 @@ RSpec.describe "New topic header button", type: :system do
         category.save!
       end
 
-      it "can't open composer" do
+      it "can open composer" do
         visit("/c/#{category.slug}/#{category.id}")
 
-        expect(page).to have_css("#new-create-topic[disabled]")
+        expect(page).to have_no_css("#create-topic")
       end
     end
   end


### PR DESCRIPTION
Following up on #42:

This PR removes state logic of this theme component so it's always active, respecting the latest core behavior of the open composer action. 

Core feature: https://github.com/discourse/discourse/pull/34211