### PR TITLE
DEV: Add backward compatibility for tag object arrays

### DIFF
--- a/javascripts/discourse/components/custom-header-topic-button.gjs
+++ b/javascripts/discourse/components/custom-header-topic-button.gjs
@@ -32,7 +32,11 @@ export default class CustomHeaderTopicButton extends Component {
         .filter((t) => !["none", "all"].includes(t))
         .join(",");
     } else {
-      return this.topic?.model?.tags?.join(",");
+      // TODO(https://github.com/discourse/discourse/pull/36678): The string check can be
+      // removed using .discourse-compatibility once the PR is merged.
+      return this.topic?.model?.tags
+        ?.map((t) => (typeof t === "string" ? t : t.name))
+        .join(",");
     }
   }
 

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "New topic header button", type: :system do
   fab!(:post_with_tags) { Fabricate(:post, user:, topic: topic_with_tags) }
 
   let(:mini_tag_chooser) { PageObjects::Components::SelectKit.new(".mini-tag-chooser") }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer) { PageObjects::Components::Composer.new }
 
   context "with logged in user" do
     before { sign_in(user) }
@@ -31,15 +33,15 @@ RSpec.describe "New topic header button", type: :system do
     end
 
     it "should open the composer to the correct category when the header button is clicked from a topic page" do
-      visit(topic.url)
+      topic_page.visit_topic(topic)
       find("#new-create-topic").click
 
-      expect(page).to have_css(".category-input [data-category-id='#{category.id}']")
+      expect(composer.category_chooser).to have_selected_value(category.id)
     end
 
     it "should open the composer with the correct tags when the header button is clicked from a topic page with tags" do
       SiteSetting.tagging_enabled = true
-      visit(topic_with_tags.url)
+      topic_page.visit_topic(topic_with_tags)
       find("#new-create-topic").click
 
       expect(mini_tag_chooser).to have_selected_name(tag.name)

--- a/spec/system/header_new_topic_button_spec.rb
+++ b/spec/system/header_new_topic_button_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe "New topic header button", type: :system do
   fab!(:user) { Fabricate(:user, trust_level: TrustLevel[1]) }
   fab!(:category)
   fab!(:category2, :category)
+  fab!(:tag)
   fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:topic_with_tags) { Fabricate(:topic, category: category, tags: [tag]) }
   fab!(:post) { Fabricate(:post, user:, topic:) }
+  fab!(:post_with_tags) { Fabricate(:post, user:, topic: topic_with_tags) }
+
+  let(:mini_tag_chooser) { PageObjects::Components::SelectKit.new(".mini-tag-chooser") }
 
   context "with logged in user" do
     before { sign_in(user) }
@@ -30,6 +35,14 @@ RSpec.describe "New topic header button", type: :system do
       find("#new-create-topic").click
 
       expect(page).to have_css(".category-input [data-category-id='#{category.id}']")
+    end
+
+    it "should open the composer with the correct tags when the header button is clicked from a topic page with tags" do
+      SiteSetting.tagging_enabled = true
+      visit(topic_with_tags.url)
+      find("#new-create-topic").click
+
+      expect(mini_tag_chooser).to have_selected_name(tag.name)
     end
 
     context "when new_topic_button_text is empty" do


### PR DESCRIPTION
What is the problem?

Discourse core PR #36678 changes `topic.tags` from a string array
(e.g., `["support", "bug"]`) to an object array (e.g.,
`[{id: 12, name: "support", slug: "support"}]`). This breaks the
`CustomHeaderTopicButton#currentTag` getter which joins tags directly
using `this.topic?.model?.tags?.join(",")`.

What is the solution?

Update the `currentTag` getter to map tags and extract names using
`typeof t === "string" ? t : t.name` before joining. This ensures
backward compatibility with both the old string format and the new
object format.
