### PR TITLE
FIX: Visit canonical tag route directly in test

### DIFF
--- a/test/acceptance/header-topic-button-test.js
+++ b/test/acceptance/header-topic-button-test.js
@@ -9,7 +9,7 @@ acceptance("Custom Header Topic Button | tag route", function (needs) {
   needs.settings({ tagging_enabled: true });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/important/l/latest.json", () => {
+    server.get("/tag/:tag_id/l/latest.json", () => {
       return helper.response(
         cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
       );
@@ -26,7 +26,7 @@ acceptance("Custom Header Topic Button | tag route", function (needs) {
   });
 
   test("tag route provides tag name in route attributes", async function (assert) {
-    await visit("/tag/important");
+    await visit("/tag/important/1");
 
     const router = getOwner(this).lookup("service:router");
     const tagName = router.currentRoute.attributes?.tag?.name;


### PR DESCRIPTION
What is the problem?

The tag route test visits `/tag/important` which hits the
`TagLegacyRedirect` route. This triggers an AJAX request to
`/tag/important/info.json` that is not handled by the pretender,
causing the test to fail.

What is the solution?

Visit the canonical `/tag/:tag_slug/:tag_id` route directly
(`/tag/important/1`) to bypass the legacy redirect, and update the
pretender to use a parameterized `/tag/:tag_id/l/latest.json` pattern.